### PR TITLE
Cache functions with JAX export

### DIFF
--- a/econpizza/config.py
+++ b/econpizza/config.py
@@ -5,10 +5,13 @@ class EconPizzaConfig(dict):
     def __init__(self, *args, **kwargs):
         super(EconPizzaConfig, self).__init__(*args, **kwargs)
         self.__dict__ = self
+        self.enable_persistent_cache = False
         self.enable_jax_persistent_cache = False
         self.jax_cache_folder = "__jax_cache__"
+        self.econpizza_cache_folder = "__econpizza_cache__"
 
         self._setup_persistent_cache_map = {
+            "enable_persistent_cache": self.setup_persistent_cache,
             "enable_jax_persistent_cache": self.setup_persistent_cache_jax
         }
 
@@ -29,6 +32,14 @@ class EconPizzaConfig(dict):
         folder_path = os.path.join(cwd, folder_name)
         os.makedirs(folder_path, exist_ok=True)
         return folder_path
+    
+    def setup_persistent_cache(self):
+        """Create econpizza cache folder. If caching is enabled, sets up the cache."""
+        if not os.path.exists(self.econpizza_cache_folder):
+            folder_path_pizza = self._create_cache_dir(self.econpizza_cache_folder)
+            self.econpizza_cache_folder = folder_path_pizza
+        else:
+            folder_path_pizza = self.econpizza_cache_folder
 
     def setup_persistent_cache_jax(self):
         """Setup JAX persistent cache if enabled."""

--- a/econpizza/testing/test_config.py
+++ b/econpizza/testing/test_config.py
@@ -29,6 +29,10 @@ def os_getcwd_create():
         shutil.rmtree(test_cache_folder)
 
 def test_config_default_values():
+  assert ep.config["enable_persistent_cache"] == False
+  assert ep.config.econpizza_cache_folder == "__econpizza_cache__"
+
+def test_jax_persistent_cache_config_default_values():
   assert ep.config["enable_jax_persistent_cache"] == False
   assert ep.config.jax_cache_folder == "__jax_cache__"
 
@@ -38,6 +42,12 @@ def test_config_jax_default_values():
    assert jax.config.values["jax_persistent_cache_min_compile_time_secs"] == 1.0
 
 @patch("os.makedirs")
+# @pytest.mark.skip(reason="Skipping until enable_persistent_cache gets exposed for end users")
+def test_config_enable_persistent_cache(mock_makedirs):
+  ep.config["enable_persistent_cache"] = True
+  mock_makedirs.assert_any_call(os.path.join(os.getcwd(), "__econpizza_cache__"), exist_ok=True)
+
+@patch("os.makedirs")
 @patch("jax.config.update")
 def test_config_enable_jax_persistent_cache(mock_jax_update, mock_makedirs):
   ep.config["enable_jax_persistent_cache"] = True
@@ -45,6 +55,14 @@ def test_config_enable_jax_persistent_cache(mock_jax_update, mock_makedirs):
 
   mock_jax_update.assert_any_call("jax_compilation_cache_dir", os.path.join(os.getcwd(), "__jax_cache__"))
   mock_jax_update.assert_any_call("jax_persistent_cache_min_compile_time_secs", 0)
+
+@patch("os.makedirs")
+# @pytest.mark.skip(reason="Skipping until enable_persistent_cache gets exposed for end users")
+def test_config_set_econpizza_folder(mock_makedirs):
+  ep.config.econpizza_cache_folder = "test1"
+  ep.config["enable_persistent_cache"] = True
+
+  mock_makedirs.assert_any_call(os.path.join(os.getcwd(), "test1"), exist_ok=True)
 
 @patch("os.makedirs")
 @patch("jax.config.update")
@@ -59,6 +77,22 @@ def test_config_jax_folder_set_from_outside(mock_jax_update):
     mock_jax_update("jax_compilation_cache_dir", "jax_from_outside")
     ep.config["enable_jax_persistent_cache"] = True
     mock_jax_update.assert_any_call("jax_compilation_cache_dir", "jax_from_outside")
+
+@patch("os.path.exists")
+@patch("os.makedirs")
+# @pytest.mark.skip(reason="Skipping until enable_persistent_cache gets exposed for end users")
+def test_econpizza_cache_folder_not_created_second_time(mock_makedirs, mock_exists):
+  # Set to first return False when the folder is not created, then True when the folder is created
+  mock_exists.side_effect = [False, True]
+
+  # When called for the first time, a cache folder should be created(default is __econpizza_cache__)
+  ep.config["enable_persistent_cache"] = True
+  mock_makedirs.assert_any_call(os.path.join(os.getcwd(), "__econpizza_cache__"), exist_ok=True)
+  # Now reset the mock so that the calls are 0 again.
+  mock_makedirs.reset_mock()
+  # The second time we should not create a folder
+  ep.config["enable_persistent_cache"] = True
+  mock_makedirs.assert_not_called()
 
 @patch("os.path.exists")
 @patch("os.makedirs")
@@ -78,6 +112,14 @@ def test_jax_cache_folder_not_created_second_time(mock_jax_update, mock_makedirs
    ep.config["enable_jax_persistent_cache"] = True
    mock_makedirs.assert_not_called()
    assert mock_jax_update.call_count == 0
+
+# @pytest.mark.skip(reason="Skipping until enable_persistent_cache gets exposed for end users")
+def test_config_enable_persistent_cache_called_after_model_load():
+    _ = ep.load(ep.examples.dsge)
+
+    assert os.path.exists(ep.config.econpizza_cache_folder) == False
+    ep.config["enable_persistent_cache"] = True
+    assert os.path.exists(ep.config.econpizza_cache_folder) == True
 
 def test_config_enable_jax_persistent_cache_called_after_model_load():
     _ = ep.load(ep.examples.dsge)

--- a/econpizza/utilities/cache_decorator.py
+++ b/econpizza/utilities/cache_decorator.py
@@ -1,0 +1,246 @@
+"""Decorator to handle function serialization"""
+
+import econpizza as ep
+import os
+
+try:
+    from jax import export
+except:
+    export = None
+
+import jax.numpy as jnp
+import jax
+import sys
+
+def export_and_serialize(
+    args,
+    kwargs,
+    func,
+    func_name,
+    shape_struct,
+    vjp_order,
+    skip_jitting,
+    export_with_kwargs=False,
+    reuse_first_item_scope=False
+):
+    """
+    Export and serialize a function with given symbolic shapes.
+
+    Args:
+        func (function): The function to be exported and serialized. If `skip_jitting` is True, then `func` needs to be jitted.
+        func_name (str): The name of the function to be used for the serialized file.
+        shape_struct (dict): A dictionary defining the shape and type of the function's inputs.
+        vjp_order (int): The order of the vector-Jacobian product.
+        skip_jitting (bool): Whether to skip JIT compilation.
+
+    Returns:
+        function: The exported and serialized function ready to be called.
+    """
+    scope = export.SymbolicScope()
+    poly_args = map_shape_struct_dict_to_jax_shape(shape_struct, scope)
+
+    function_to_export = func if skip_jitting else jax.jit(func)
+
+    if export_with_kwargs == True:
+        poly_kwargs = _prepare_poly_kwargs(shape_struct, kwargs, poly_args)
+        
+        exported_func: export.Exported = export.export(function_to_export)(
+            **poly_kwargs
+        )
+    else:
+        exported_func: export.Exported = export.export(function_to_export)(*poly_args)
+
+    # Save exported artifact
+    serialized_path = os.path.join(ep.config.econpizza_cache_folder, f"{func_name}")
+    serialized: bytearray = exported_func.serialize(vjp_order=vjp_order)
+    
+    with open(serialized_path, "wb") as file:
+        file.write(serialized)
+
+    
+    return exported_func.call
+
+
+def cacheable_function_with_export(
+    func_name, shape_struct, alternative_shape_struct=None, vjp_order=0, skip_jitting=False, export_with_kwargs=False, reuse_first_item_scope=False
+):
+    """
+    Decorator to replace function with exported and cached version if caching is enabled.
+
+    Args:
+        func_name (str): The name under which the function will be saved. "my_func" will be saved as "my_func.bin" on disk.
+        shape_struct (dict): A dictionary defining the shape and type of the function's inputs.
+        vjp_order (int, optional): The order of the vector-Jacobian product. Defaults to 0.
+        skip_jitting (bool, optional): Whether to skip JIT compilation. Defaults to False.
+
+    Returns:
+        function: The decorated function which uses the cached version if available, otherwise the original function.
+
+    Usage:
+        @cacheable_function_with_export("f", {"x": ("a,", jnp.float64)})
+        def f(x):
+            ...
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            if ep.config.enable_persistent_cache == True:
+                _check_jax_export_dependencies_and_raise()
+
+                def _get_func_name(shape_mismatch: bool):
+                    return f"{func_name}_alt" if shape_mismatch else func_name
+                
+                def _get_shape_struct(shape_mismatch: bool):
+                    return alternative_shape_struct if shape_mismatch and alternative_shape_struct else shape_struct
+
+                filtered_kwargs = {key: value for key, value in kwargs.items() if key in shape_struct}
+
+                # First, check if the function is already serialized
+                # If the function is serialized, deserialize it and return the .call
+                # Else, export, serialize and return the call.
+                serialized_path = os.path.join(
+                    ep.config.econpizza_cache_folder, f"{func_name}"
+                )
+                serialized = _read_serialized_function(serialized_path)
+                # Load alternative function serialized object
+                serialized_alt_path = os.path.join(
+                    ep.config.econpizza_cache_folder, f"{func_name}_alt"
+                )
+                serialized_alt = _read_serialized_function(serialized_alt_path)
+
+                if serialized_alt:
+                    cached_func = export.deserialize(serialized_alt)
+                    args_shapes, exported_shapes = _get_args_exported_shapes(args, cached_func)
+                    
+                    # If the args and specs match, call alternative export
+                    if _check_shape_dim_size(args_shapes, exported_shapes) == True:
+                        return cached_func.call(*args, **filtered_kwargs)
+                    else:
+                        pass
+
+                shape_mismatch = False
+                if serialized and alternative_shape_struct is not None and not serialized_alt:
+                    cached_func = export.deserialize(serialized)
+                    # Check shapes of cached_func.in_avals and args
+                    if not export_with_kwargs:
+                        args_shapes, exported_shapes = _get_args_exported_shapes(args, cached_func)
+
+                        # Dimensions mismatch
+                        if _check_shape_dim_size(args_shapes, exported_shapes) == False:
+                            serialized = None
+                            shape_mismatch = True
+
+
+                if serialized:
+                    cached_func = export.deserialize(serialized)
+                    return cached_func.call(*args, **filtered_kwargs)
+                else:
+                    cached_func = export_and_serialize(
+                        args=args,
+                        kwargs=kwargs,
+                        func=func,
+                        func_name=_get_func_name(shape_mismatch),
+                        shape_struct=_get_shape_struct(shape_mismatch),
+                        vjp_order=vjp_order,
+                        skip_jitting=skip_jitting,
+                        export_with_kwargs=export_with_kwargs,
+                        reuse_first_item_scope=reuse_first_item_scope
+                    )
+                    return cached_func(*args, **filtered_kwargs)
+            else:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def map_shape_struct_dict_to_jax_shape(node, scope):
+    """Generate a jax.ShapeDTypeStruct from a dictionary of polymorphic shapes.
+
+    Args:
+        node (tuple | dict | list): an element from the shape (example: ("a", jnp.int64))
+        scope (export.SymbolicScope): the scope which the symbolic shape should use. As this is constructing a whole
+        structure with related objects, they should share the same scope
+
+    Returns:
+        jax.ShapeDtypeStruct: shape struct using symbolic shape
+    """
+    if (
+        isinstance(node, tuple)
+        and (len(node) == 2
+        or len(node) == 3)
+        and not isinstance(node[0], tuple)
+    ):
+        if len(node) == 3:
+            value, dtype, constraint = node
+        else:
+            value, dtype = node
+            constraint = None
+
+        if constraint:
+            shape_poly = export.symbolic_shape(shape_spec=value, constraints=constraint)
+        else:
+            shape_poly = export.symbolic_shape(shape_spec=value, scope=scope)
+
+        if scope is None:
+            return jax.ShapeDtypeStruct(shape_poly, dtype=dtype), shape_poly[0].scope
+        else:
+            return jax.ShapeDtypeStruct(shape_poly, dtype=dtype)
+    elif isinstance(node, dict):
+        return tuple(
+            map_shape_struct_dict_to_jax_shape(v, scope) for v in node.values()
+        )
+    elif isinstance(node, (list, tuple)):
+        return type(node)(map_shape_struct_dict_to_jax_shape(v, scope) for v in node)
+    else:
+        return node
+
+
+def _read_serialized_function(serialized_path):
+    if os.path.exists(serialized_path):
+        with open(serialized_path, "rb") as file:
+            serialized = file.read()
+    else:
+        serialized = None
+
+    return serialized
+                
+def _prepare_poly_kwargs(shape_struct, kwargs, poly_args):
+    func_kwargs_names = list(shape_struct.keys())
+    poly_kwargs = {key: value for key, value in zip(func_kwargs_names, poly_args)}
+
+    for key, value in kwargs.items():
+        if key not in poly_kwargs:
+            poly_kwargs[key] = value
+
+    assert len(poly_kwargs) == len(kwargs), "Keyword argument missing in shape poly"
+
+    return poly_kwargs
+
+
+def _check_shape_dim_size(current_arg_shapes: list[tuple], exported_args_shapes: list[tuple]):
+    for current_shape, exported_shape in zip(current_arg_shapes, exported_args_shapes):
+        if len(current_shape) != len(exported_shape): return False
+    
+    return True
+
+def _get_args_exported_shapes(args, exported):
+    args_flatten, _ = jax.tree_util.tree_flatten(args)
+                        
+    args_shapes = [arg.shape if hasattr(arg, 'shape') else () for arg in args_flatten]
+    exported_shapes = [exported.shape if hasattr(exported, 'shape') else () for exported in exported.in_avals]
+
+    return args_shapes, exported_shapes
+
+    
+def _check_jax_export_dependencies_and_raise():
+    try:
+        import absl
+    except ImportError as e:
+        raise ImportError('Please install absl-py in order to use jax export')
+    
+    try:
+        import flatbuffers
+    except ImportError as e:
+        raise ImportError('Please install flatbuffers in order to use jax export')
+

--- a/econpizza/utilities/jacobian.py
+++ b/econpizza/utilities/jacobian.py
@@ -6,6 +6,8 @@ from jax._src.api import partial
 from jax._src.typing import Array
 from grgrjax import jax_print
 
+from .cache_decorator import cacheable_function_with_export
+
 
 def accumulate(i_and_j: Array, carry: (Array, Array)) -> (Array, int):
     # accumulate effects over different horizons
@@ -16,7 +18,33 @@ def accumulate(i_and_j: Array, carry: (Array, Array)) -> (Array, int):
     return jac, horizon
 
 
-@jax.jit
+@cacheable_function_with_export(
+    "get_stst_jacobian_jit",
+    {
+        "derivatives": (
+            (
+                ("a, a, 1", jnp.float64),
+                ("a, a, 1", jnp.float64),
+                ("a, a, 1", jnp.float64),
+            ),
+            ("a, b, c, d, e", jnp.float64),
+            ("c, d, e, b, a", jnp.float64),
+        ),
+        "horizon": ("", jnp.int64),
+    },
+    {
+        "derivatives": (
+            (
+                ("a, a, 1", jnp.float64),
+                ("a, a, 1", jnp.float64),
+                ("a, a, 1", jnp.float64),
+            ),
+            ("a, b, c, d, e, f", jnp.float64),
+            ("c, d, e, f, b, a", jnp.float64),
+        ),
+        "horizon": ("", jnp.int64),
+    },
+)
 def get_stst_jacobian_jit(derivatives, horizon):
     # load derivatives
     (jac_f2xLag, jac_f2x, jac_f2xPrime), jac_f2do, jac_do2x = derivatives

--- a/econpizza/utilities/newton.py
+++ b/econpizza/utilities/newton.py
@@ -5,10 +5,10 @@ from grgrjax import jax_print
 import jax
 import time
 import jax.numpy as jnp
-from functools import partial
 from jax._src.lax.linalg import lu_solve
 from grgrjax import callback_func, amax, newton_jax_jit
 
+from .cache_decorator import cacheable_function_with_export
 
 def callback_with_damp(cnt, err, fev, err_inner, dampening, ltime, verbose):
     inner = f' | inner {err_inner:.2e}'
@@ -69,7 +69,14 @@ def sweep_tridiag_down(val, i):
     fmod = jnp.linalg.solve(bmat, fval - jac_f2xLag @ fmod)
     return (jav_func, fmod, forward_mat, X, shocks), (fmod, forward_mat)
 
-
+@cacheable_function_with_export("sweep_tridiag_up", {
+    "val": (
+        ("a, b, b", jnp.float64),
+        ("a, b", jnp.float64),
+        ("b", jnp.float64),
+    ),
+    "i": ("", jnp.int64)
+})
 def sweep_tridiag_up(val, i):
     forward_mat, fvals, fval = val
     # go backwards in time

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     package_data={"econpizza": ["examples/*"]},
     extras_require={
         'linear': ['grgrlib>=0.1.22'],
+        'cache': ['absl-py', 'flatbuffers']
     },
     install_requires=[
         "jax>=0.4.13",


### PR DESCRIPTION
Adds the ability to save a function on disk with flexible input shapes using JAX export module.
The decorator `cacheable_function_with_export`  takes a function and it's shape polymorphism information exports it and saves it on disk and returns the exported artefact. This happens if the config option `enable_persistent_cache` is `True`. Otherwise, the decorator returns the original function.
Used as:
```python
@cacheable_function_with_export("f", {
      # place here the shape of x in a tuple, with the first item symbolic shape spec and the second as the dtype
      # "a, b" is the symbolic shape information passed to jax export api. Note, a != b
      "x": ("a, b", jnp.float64)
})
def f(x):
      .....
```
A function can be exported as:
- with `args` only (default)
- with `kwargs` only - option `export_with_kwargs` should be passed as `True`
```python
@cacheable_function_with_export("f", shape_struct, export_with_kwargs=True)
```
- with `static_argnums` and `static_argnames` from `jax.jit`
```python
@cacheable_function_with_export("f", shape_struct, skip_jitting=True)
@partial(jax.jit, static_argnums=(1,))
```
- with export `vjp_order` to support reverse-mode AD
```python
@cacheable_function_with_export("f", shape_struct, vjp_order=1)
```
- with alternative shape structure. This case is when a function is called with different dimension arguments between calls.
For example, call `x` can be 2D array and 3D array. The function should be exported twice and on subsequent calls, the decorator decides which function to load based on the arguments passed.
Usage:
```python
@cacheable_function_with_export("f", {
      # first export structure
      "x": ("a, b", jnp.float64)
},
{
   # alternative export structure
   "x": ("a, b, c", jnp.float64)
}
)
def f(x):
      .....
```

### Limitations
Currently, there's no support for forward-mode AD offered by JAX export. Attempts to export a function used in `jvp` results in an error. The `vmap` transformation is not supported as well, as there is not `custom_batching_rule` developed for exported artefacts.